### PR TITLE
Fix light blinking in clocktown

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -1094,6 +1094,7 @@ static void gfx_sp_pop_matrix(uint32_t count) {
             }
         }
     }
+    g_rsp.lights_changed = true;
 }
 
 static float gfx_adjust_x_for_aspect_ratio(float x) {


### PR DESCRIPTION
We cache the light directions transformed to the current model matrix so we don't have to do it for each vertex. However, we were not invalidating that cache when popped from the stack, only when pushing.