### PR TITLE
fix pop back without size check

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2567,7 +2567,9 @@ Gfx* GfxExecStack::ret() {
 
     while (cmd_stack.size() > 0 && cmd_stack.top() == nullptr) {
         cmd_stack.pop();
-        gfx_path.pop_back();
+        if (!gfx_path.empty()) {
+            gfx_path.pop_back();
+        }
     }
     return cmd;
 }


### PR DESCRIPTION
This popback was missing a size check which allowed it to popback on an empty vector which is UB and caused an issue later with a `while !empty()` stalling out.