### PR TITLE
update frame buffers when width changes

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3312,7 +3312,8 @@ void gfx_start_frame(void) {
     }
     gfx_current_dimensions.aspect_ratio = (float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height;
 
-    if (gfx_current_dimensions.height != gfx_prev_dimensions.height) {
+    if (gfx_current_dimensions.width != gfx_prev_dimensions.width ||
+        gfx_current_dimensions.height != gfx_prev_dimensions.height) {
         for (auto& fb : framebuffers) {
             uint32_t width = fb.second.orig_width, height = fb.second.orig_height;
             gfx_adjust_width_height_for_scale(width, height);


### PR DESCRIPTION
We were only updating frame buffer sizes when the height of the window changes. Now also check for a change in width too.